### PR TITLE
Fix carousel CSS imports and theatre tag styling

### DIFF
--- a/app/blog/posts/show-maxxing.mdx
+++ b/app/blog/posts/show-maxxing.mdx
@@ -2,7 +2,7 @@
 title: The Art of Show-Maxxing
 publishedAt: 2025-08-01
 summary: How to cram as many Broadway shows as humanly possible into a single NYC weekend.
-tag: theatre
+tag: Theatre
 ---
 
 My first trip to New York City (in 2022) was with my then-fiancee Sophia and her friend Rose. Despite living in the city with the second-largest theatre district (Cleveland's Playhouse Square), it was this trip that truly unlocked the magic of theatre for me.

--- a/app/blog/posts/values.mdx
+++ b/app/blog/posts/values.mdx
@@ -136,24 +136,6 @@ I assume there is some amount of change in values as you go through life, but I 
 16. Valuing a career
 17. Valuing charity and volunteering
 
-18. Creating things
-19. Views on the meaning of suffering
-20. Valuing spirituality
-21. Working in a creative environment
-22. Appreciating beauty in nature, music, etc.
-23. Valuing love
-24. Views on morality, honesty, integrity
-25. Valuing education, professional, and personal growth
-26. Valuing leisure, hobbies, and recreation
-27. Valuing mental health
-28. Valuing romantic partnerships
-29. Valuing parent, child, and other family relationships
-30. Attitudes towards inevitable events such as illness, death, and loss
-31. Valuing friendships
-32. Valuing physical health
-33. Valuing a career
-34. Valuing charity and volunteering
-
 ### Why the changes?
 
 - I will **not** value creating something if I believe it is the wrong thing to do or if I believe it will lead to suffering.

--- a/app/components/ContentCarousel.tsx
+++ b/app/components/ContentCarousel.tsx
@@ -9,15 +9,11 @@ import { ReactNode } from 'react'
 // Simple date formatting function for client component
 function formatDate(dateString: string | undefined): string {
   if (!dateString) return ''
-  const date = new Date(dateString)
+  // Ensure the date is interpreted in UTC to match server-side formatting
+  const date = new Date(dateString + 'T00:00:00Z')
   const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-  return `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`
+  return `${months[date.getUTCMonth()]} ${date.getUTCDate()}, ${date.getUTCFullYear()}`
 }
-
-// Import Swiper styles
-import 'swiper/css'
-import 'swiper/css/navigation'
-import 'swiper/css/free-mode'
 
 interface ContentCarouselProps {
   title: string | ReactNode

--- a/app/components/ui/badge.tsx
+++ b/app/components/ui/badge.tsx
@@ -18,6 +18,7 @@ const badgeVariants = cva(
         // Collection-specific variants
               fractal: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300",
               "beginner-programmer": "bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-300",
+              theatre: "bg-pink-100 text-pink-800 dark:bg-pink-900 dark:text-pink-300",
               // Project status variants
               "published": "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
               "deployed": "bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300",

--- a/app/components/utils.ts
+++ b/app/components/utils.ts
@@ -9,7 +9,8 @@ export function cn(...inputs: ClassValue[]) {
 export function getBadgeVariant(collection?: string, tag?: string) {
   // Check for project-specific tags first
   if (tag) {
-    switch (tag.toLowerCase()) {
+    const normalizedTag = tag.toLowerCase();
+    switch (normalizedTag) {
       case 'published':
         return 'published'
       case 'deployed':
@@ -27,6 +28,8 @@ export function getBadgeVariant(collection?: string, tag?: string) {
         return 'playhouse-square'
       case 'broadway (touring)':
         return 'broadway-touring'
+      case 'theatre':
+        return 'theatre'
       // If it's not a project tag, fall through to collection logic
     }
   }

--- a/app/for-fun/theatre/TheatreClient.tsx
+++ b/app/for-fun/theatre/TheatreClient.tsx
@@ -64,7 +64,7 @@ export default function TheatreClient({ reviews }: TheatreClientProps) {
           const locationTag = getShowDistrict(displayName)
           
           return {
-            date: formatDate(review.metadata.publishedAt, false),
+            date: formatDate(review.metadata.publishedAt, true),
             title: displayName,
             href: `/for-fun/theatre/${review.slug}`,
             extra: formatRank(rank, totalShows),

--- a/app/global.css
+++ b/app/global.css
@@ -2,6 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Swiper styles */
+@import 'swiper/css';
+@import 'swiper/css/navigation';
+@import 'swiper/css/free-mode';
+
 ::selection {
   background-color: #47a3f3;
   color: #fefefe;


### PR DESCRIPTION
- Move Swiper CSS imports to global.css to fix broken carousel functionality
- Add theatre badge variant with pink styling
- Update show-maxxing blog post to use 'Theatre' tag
- Fix theatre page date formatting to include year for consistency