### PR TITLE
Featured portfolio and blog sections, project CTAs

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,4 +1,5 @@
-import { getBlogPosts, formatDate } from 'app/blog/utils'
+import { getBlogPosts, getFeaturedBlogPosts, formatDate } from 'app/blog/utils'
+import { ContentListHomeResponsive } from 'app/components/ContentListHomeResponsive'
 import { ContentList } from 'app/components/ContentListItem'
 
 export const metadata = {
@@ -7,10 +8,25 @@ export const metadata = {
 }
 
 export default function Page() {
+  const featuredBlogs = getFeaturedBlogPosts().slice(0, 6)
   const allBlogs = getBlogPosts().sort((a, b) => new Date(b.metadata.publishedAt).getTime() - new Date(a.metadata.publishedAt).getTime())
   return (
     <section>
       <h1 className="font-semibold text-2xl mb-8 tracking-tighter">Ben Beaudet's Blog</h1>
+      <ContentListHomeResponsive
+        title="Featured Posts"
+        variant="compact"
+        showViewAll={false}
+        items={featuredBlogs.map((post) => ({
+          date: post.metadata.publishedAt,
+          title: post.metadata.title,
+          href: `/blog/${post.slug}`,
+          tags: post.metadata.tags || [],
+          collection: post.metadata.collection,
+          summary: post.metadata.summary,
+        }))}
+      />
+      <h2 className="text-xl font-semibold mb-4">All Posts</h2>
       <ContentList
         items={allBlogs}
         getItemProps={(post) => ({

--- a/app/blog/posts/inner-child.mdx
+++ b/app/blog/posts/inner-child.mdx
@@ -3,6 +3,7 @@ title: "Embracing my Inner Child"
 publishedAt: "2025-11-10"
 summary: "My story of creative world-building from childhood all the way to adulthood and career"
 tags: []
+featured: 4
 ---
 
 ## Imaginary Worlds

--- a/app/blog/posts/taking-the-leap.mdx
+++ b/app/blog/posts/taking-the-leap.mdx
@@ -2,6 +2,7 @@
 title: 'Taking the Leap'
 date: '2025-05-12'
 summary: 'Discovering the world of coding, quitting my job, and expanding my limits of what is possible'
+featured: 6
 ---
 
 ### Expanding Possibilities

--- a/app/blog/posts/wk1-reflection.mdx
+++ b/app/blog/posts/wk1-reflection.mdx
@@ -4,6 +4,7 @@ title: 'Confrontations'
 date: '2025-06-07'
 summary: 'Reflecting on the mental/emotional challenges and lessons learned from my first week at Fractal's Bootcamp in NYC'
 tags: ["Fractal 1"]
+featured: 5
 ---
 
 _Week 1 of Fractal Tech's AI Accelerator & Engineering Bootcamp_

--- a/app/blog/posts/wk4-reflection.mdx
+++ b/app/blog/posts/wk4-reflection.mdx
@@ -1,9 +1,10 @@
 ---
 collection: "fractal-weekly-reflection"
-title: "Abstractions"
+title: "Can a single sentence capture all of life?"
 publishedAt: "2025-06-28"
 summary: "The infinite nature of data and the applied philosophy of SWE"
 tags: ["Fractal 4"]
+featured: 1
 ---
 
 _Week 4 of Fractal Tech's AI Accelerator & Engineering Bootcamp_

--- a/app/blog/posts/wk5-reflection.mdx
+++ b/app/blog/posts/wk5-reflection.mdx
@@ -4,6 +4,7 @@ title: "Pulling Back the Curtain"
 publishedAt: "2025-07-05"
 summary: ""
 tags: ["Fractal 5"]
+featured: 3
 ---
 
 _Week 5 of Fractal Tech's AI Accelerator & Engineering Bootcamp_

--- a/app/blog/posts/wk6-reflection.mdx
+++ b/app/blog/posts/wk6-reflection.mdx
@@ -4,6 +4,7 @@ title: "All Gas, No Brakes"
 publishedAt: "2025-07-12"
 summary: ""
 tags: ["Fractal 6"]
+featured: 2
 ---
 
 _Week 6 of Fractal Tech's AI Accelerator & Engineering Bootcamp_

--- a/app/blog/utils.ts
+++ b/app/blog/utils.ts
@@ -9,7 +9,23 @@ type Metadata = {
   image?: string
   tags?: string[]
   collection?: string
+  featured?: number
   [key: string]: any
+}
+
+function parseScalarValue(value: string) {
+  return value.replace(/^['"](.*)['"]$/, '$1')
+}
+
+function parseTagsValue(value: string) {
+  try {
+    const cleanValue = parseScalarValue(value)
+    const parsedTags = JSON.parse(cleanValue)
+    return Array.isArray(parsedTags) ? parsedTags : [parsedTags]
+  } catch {
+    const cleanValue = parseScalarValue(value)
+    return cleanValue.split(',').map(tag => parseScalarValue(tag.trim()))
+  }
 }
 
 function parseFrontmatter(fileContent: string) {
@@ -27,31 +43,39 @@ function parseFrontmatter(fileContent: string) {
   let metadata: Partial<Metadata> = {}
 
   frontMatterLines.forEach((line) => {
-    if (line.trim() && line.includes(': ')) {
-      let [key, ...valueArr] = line.split(': ')
-      let value = valueArr.join(': ').trim()
+    if (line.trim() && line.includes(':')) {
+      let [key, ...valueArr] = line.split(':')
+      const trimmedKey = key.trim()
+      let value = valueArr.join(':').trim()
       
-      // Handle tags array specially
-      if (key.trim() === 'tags') {
-        try {
-          // Remove outer quotes if present
-          const cleanValue = value.replace(/^['"](.*)['"]$/, '$1')
-          // Parse as JSON array
-          const parsedTags = JSON.parse(cleanValue)
-          metadata[key.trim() as keyof Metadata] = Array.isArray(parsedTags) ? parsedTags : [parsedTags]
-        } catch {
-          // Fallback to comma-separated parsing
-          const cleanValue = value.replace(/^['"](.*)['"]$/, '$1')
-          metadata[key.trim() as keyof Metadata] = cleanValue.split(',').map(tag => tag.trim().replace(/^['"](.*)['"]$/, '$1'))
-        }
+      if (trimmedKey === 'tags') {
+        metadata.tags = parseTagsValue(value)
+      } else if (trimmedKey === 'featured') {
+        metadata.featured = Number(value)
       } else {
-        value = value.replace(/^['"](.*)['"]$/, '$1') // Remove quotes
-        metadata[key.trim() as keyof Metadata] = value
+        metadata[trimmedKey as keyof Metadata] = parseScalarValue(value)
       }
     }
   })
 
   return { metadata: metadata as Metadata, content }
+}
+
+function sortByFeatured<T extends { metadata: Metadata }>(items: T[]) {
+  return items
+    .filter(item => item.metadata.featured !== undefined && !Number.isNaN(item.metadata.featured))
+    .sort((a, b) => {
+      const aFeatured = a.metadata.featured ?? Number.MAX_SAFE_INTEGER
+      const bFeatured = b.metadata.featured ?? Number.MAX_SAFE_INTEGER
+
+      if (aFeatured !== bFeatured) {
+        return aFeatured - bFeatured
+      }
+
+      const aDate = new Date(a.metadata.publishedAt || '1900-01-01')
+      const bDate = new Date(b.metadata.publishedAt || '1900-01-01')
+      return bDate.getTime() - aDate.getTime()
+    })
 }
 
 function getMDXFiles(dir) {
@@ -89,6 +113,10 @@ export function getBlogPosts() {
   }))
   
   return allPosts
+}
+
+export function getFeaturedBlogPosts() {
+  return sortByFeatured(getBlogPosts())
 }
 
 export function formatDate(date: string | undefined, includeRelative = false) {

--- a/app/components/ContentListHomeResponsive.tsx
+++ b/app/components/ContentListHomeResponsive.tsx
@@ -18,6 +18,11 @@ interface ContentListHomeResponsiveProps {
     collection?: string
     image?: string
     video?: string
+    ctas?: Array<{
+      label: string
+      href: string
+      icon?: string
+    }>
   }>
 }
 
@@ -49,9 +54,9 @@ export function ContentListHomeResponsive({
             {items.map((item, index) => {
               const hasMedia = !!(item.image || item.video)
               return (
-              <Link key={`item-${item.title}-${index}`} href={item.href} className="block group">
-                <div 
-                  className={`px-4 py-3 rounded-lg border border-neutral-200 dark:border-neutral-800 hover:border-neutral-300 dark:hover:border-neutral-700 transition-all duration-300 hover:shadow-lg hover:-translate-y-1 hover:scale-[1.02] flex flex-col justify-between relative overflow-hidden ${
+              <article key={`item-${item.title}-${index}`} className="group relative">
+                <div
+                  className={`px-4 py-3 rounded-lg border border-neutral-200 dark:border-neutral-800 group-hover:border-neutral-300 dark:group-hover:border-neutral-700 transition-all duration-300 group-hover:shadow-lg group-hover:-translate-y-1 group-hover:scale-[1.02] flex flex-col justify-between relative overflow-hidden ${
                     hasMedia ? 'h-48' : 'h-32'
                   }`}
                   style={{
@@ -76,8 +81,11 @@ export function ContentListHomeResponsive({
                   {hasMedia && (
                     <div className="absolute inset-0 bg-black/60 backdrop-blur-[0.5px]"></div>
                   )}
+                  <Link href={item.href} className="absolute inset-0 z-10">
+                    <span className="sr-only">View {item.title}</span>
+                  </Link>
                   
-                  <div className={`flex flex-col h-full ${hasMedia ? 'relative z-10' : ''}`}>
+                  <div className={`flex flex-col h-full pointer-events-none ${hasMedia ? 'relative z-20' : 'relative z-20'}`}>
                     <div className="flex flex-col gap-1 mb-2">
                       <h3 className={`font-medium transition-colors text-sm ${
                         hasMedia 
@@ -109,32 +117,48 @@ export function ContentListHomeResponsive({
                         {item.summary}
                       </p>
                     )}
-                    {item.date && (
-                      <span className={`text-xs mt-auto text-right ${
-                        hasMedia 
-                          ? 'text-neutral-300 drop-shadow-lg' 
-                          : 'text-neutral-400 dark:text-neutral-500'
-                      }`}>
-                        {getRelativeDate(item.date)}
-                      </span>
+                    {(item.date || item.ctas?.length) && (
+                      <div className="mt-auto flex items-end justify-between gap-2">
+                        {item.ctas?.length ? (
+                          <div className="flex flex-wrap gap-1 pointer-events-auto">
+                            {item.ctas.map((cta, ctaIndex) => (
+                              <a
+                                key={`${cta.href}-${ctaIndex}`}
+                                href={cta.href}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className={`rounded-full px-2 py-1 text-[10px] font-medium transition-colors ${
+                                  hasMedia
+                                    ? 'bg-white/20 text-white hover:bg-white/30 border border-white/30 backdrop-blur-sm'
+                                    : 'bg-neutral-100 text-neutral-700 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700'
+                                }`}
+                              >
+                                {cta.icon && <span className="mr-1">{cta.icon}</span>}
+                                {cta.label}
+                              </a>
+                            ))}
+                          </div>
+                        ) : (
+                          <span />
+                        )}
+                        {item.date && (
+                          <span className={`text-xs whitespace-nowrap ${
+                            hasMedia 
+                              ? 'text-neutral-300 drop-shadow-lg' 
+                              : 'text-neutral-400 dark:text-neutral-500'
+                          }`}>
+                            {getRelativeDate(item.date)}
+                          </span>
+                        )}
+                      </div>
                     )}
                   </div>
                 </div>
-              </Link>
+              </article>
               )
             })}
           </div>
         </div>
-        {showViewAll && viewAllHref && (
-          <div className="flex justify-center mt-6">
-            <Link 
-              href={viewAllHref}
-              className="text-sm text-neutral-600 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200 transition-colors"
-            >
-              {viewAllText} →
-            </Link>
-          </div>
-        )}
       </div>
     )
   }
@@ -186,16 +210,6 @@ export function ContentListHomeResponsive({
           </Link>
         ))}
       </div>
-      {showViewAll && viewAllHref && (
-        <div className="flex justify-center mt-6">
-          <Link 
-            href={viewAllHref}
-            className="text-sm text-neutral-600 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200 transition-colors"
-          >
-            {viewAllText} →
-          </Link>
-        </div>
-      )}
     </div>
   )
 } 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,21 +1,11 @@
 import { ContentListHomeResponsive } from 'app/components/ContentListHomeResponsive'
 import { Introduction } from 'app/components/Introduction'
-import { getPortfolioProjects } from 'app/portfolio/utils'
-import { getBlogPosts } from 'app/blog/utils'
+import { getFeaturedPortfolioProjects } from 'app/portfolio/utils'
+import { getFeaturedBlogPosts } from 'app/blog/utils'
 
 export default function Page() {
-  // Fetch data from each section
-  const portfolioProjects = getPortfolioProjects().sort((a, b) => {
-    const aDate = new Date(a.metadata.completedAt || '1900-01-01')
-    const bDate = new Date(b.metadata.completedAt || '1900-01-01')
-    return bDate.getTime() - aDate.getTime() // Newest first
-  }).slice(0, 9)
-
-  const blogPosts = getBlogPosts().sort((a, b) => {
-    const aDate = new Date(a.metadata.publishedAt || '1900-01-01')
-    const bDate = new Date(b.metadata.publishedAt || '1900-01-01')
-    return bDate.getTime() - aDate.getTime() // Newest first
-  }).slice(0, 9)
+  const portfolioProjects = getFeaturedPortfolioProjects()
+  const blogPosts = getFeaturedBlogPosts()
 
   return (
     <div className="overflow-x-hidden">
@@ -26,7 +16,7 @@ export default function Page() {
         <ContentListHomeResponsive 
           title={
             <div className="flex items-center gap-2">
-              <span>Portfolio</span>
+              <span>Featured Projects</span>
               <span className="text-sm text-neutral-600 dark:text-neutral-400 font-normal">
                 (<a href="/portfolio/resume" className="underline hover:text-neutral-800 dark:hover:text-neutral-200 transition-colors">resume</a>)
               </span>
@@ -40,13 +30,14 @@ export default function Page() {
             image: project.metadata.image,
             video: project.metadata.video,
             summary: project.metadata.summary,
+            ctas: project.metadata.ctas,
           }))}
           viewAllHref="/portfolio"
           viewAllText="see all Projects"
           variant="compact"
         />
         <ContentListHomeResponsive 
-          title="Blog Posts"
+          title="Featured Blogs"
           items={blogPosts.map((post) => ({
             date: post.metadata.publishedAt,
             title: post.metadata.title,

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -1,5 +1,4 @@
-import { getPortfolioProjects } from 'app/portfolio/utils'
-import { formatDate } from 'app/blog/utils'
+import { getFeaturedPortfolioProjects, getPortfolioProjects } from 'app/portfolio/utils'
 import { ContentListHomeResponsive } from 'app/components/ContentListHomeResponsive'
 
 export const metadata = {
@@ -8,6 +7,7 @@ export const metadata = {
 }
 
 export default function Page() {
+  const featuredProjects = getFeaturedPortfolioProjects().slice(0, 6)
   const allProjects = getPortfolioProjects().sort((a, b) => {
     // Sort by date, newest first
     const aDate = new Date(a.metadata.completedAt || '1900-01-01')
@@ -21,7 +21,23 @@ export default function Page() {
         View Resume
       </a>
       <ContentListHomeResponsive
-        title="Portfolio Projects"
+        title="Featured Projects"
+        variant="compact"
+        showViewAll={false}
+        items={featuredProjects.map(project => ({
+          date: project.metadata.completedAt,
+          title: project.metadata.title,
+          href: `/portfolio/${project.slug}`,
+          tags: project.metadata.tags || [],
+          summary: project.metadata.summary,
+          image: project.metadata.image,
+          video: project.metadata.video,
+          ctas: project.metadata.ctas,
+          collection: 'portfolio'
+        }))}
+      />
+      <ContentListHomeResponsive
+        title="All Projects"
         variant="compact"
         showViewAll={false}
         items={allProjects.map(project => ({
@@ -32,6 +48,7 @@ export default function Page() {
           summary: project.metadata.summary,
           image: project.metadata.image,
           video: project.metadata.video,
+          ctas: project.metadata.ctas,
           collection: 'portfolio'
         }))}
       />

--- a/app/portfolio/projects/birkdale.mdx
+++ b/app/portfolio/projects/birkdale.mdx
@@ -4,6 +4,7 @@ completedAt: "2019-05-29"
 summary: "An innovative new medical device for helping therapy patients recover feeling in specific body parts"
 tags: ["Firmware", "Mechanical"]
 image: "/images-portfolio/birkdale/handshake1.jpeg"
+featured: 6
 ---
 
 _Helping stroke patients regain feeling with a rehab therapy device utilizing Bluetooth, touch sensors, haptic feedback, and ergonomic CAD designs_

--- a/app/portfolio/projects/cerelog.mdx
+++ b/app/portfolio/projects/cerelog.mdx
@@ -4,6 +4,7 @@ completedAt: "2025-06-27"
 summary: "Collecting EEG brainwave data for an innovative neuromodulation device"
 tags: ["Firmware"]
 image: "/images-portfolio/brainwaves.jpg"
+featured: 3
 ---
 
 _Designing firmware to measure and transmit brainwave data between EEG devices and computers through serial communication_

--- a/app/portfolio/projects/or-free.mdx
+++ b/app/portfolio/projects/or-free.mdx
@@ -1,8 +1,9 @@
 ---
-title: "Portable Surgery Demos"
+title: "Portable Surgery Kits"
 completedAt: "2023-11-20"
 summary: "A portable kit allowing demonstration of surgical cameras in the absence of a full operating room"
 tags: ["Mechanical"]
+featured: 5
 ---
 
 _Designing a self-contained kit for on-the-go demonstrations of the first wireless MIS surgical device_

--- a/app/portfolio/projects/rollio-web.mdx
+++ b/app/portfolio/projects/rollio-web.mdx
@@ -7,6 +7,11 @@ githubUrl: "https://github.com/bbeaudet-dev/rollio"
 liveUrl: "https://rollio.vercel.app"
 tags: ["Game Dev", "Software"]
 image: "/images-portfolio/rollio/Rollio-sceenshot.jpg"
+ctas:
+  - label: "Play in Browser"
+    href: "https://rollio.vercel.app"
+  - label: "View on GitHub"
+    href: "https://github.com/bbeaudet-dev/rollio"
 ---
 
 _A web-based version of a dice-rolling roguelike inspired by Balatro and Farkle_

--- a/app/portfolio/projects/smart-mirror.mdx
+++ b/app/portfolio/projects/smart-mirror.mdx
@@ -7,6 +7,7 @@ githubUrl: "https://github.com/bbeaudet-dev/ai-smart-mirror"
 liveUrl: ""
 tags: ["Software", "AI", "Mechanical"]
 image: "/images-portfolio/smart-mirror/smart-mirror1.jpg"
+featured: 2
 ---
 
 _An Ai-powered Smart Mirror that gasses up your outfit_

--- a/app/portfolio/projects/theatre-diary.mdx
+++ b/app/portfolio/projects/theatre-diary.mdx
@@ -6,6 +6,12 @@ image: "/images-portfolio/theatre-diary.jpg"
 technologies: "TypeScript, React Native, Expo"
 githubUrl: "https://github.com/bbeaudet-dev/theatre-diary"
 tags: ["Software"]
+featured: 1
+ctas:
+  - label: "View on App Store"
+    href: "https://apps.apple.com/us/app/stageworth/id6761304800"
+  - label: "Visit Website"
+    href: "https://stageworth.vercel.app/"
 ---
 
 _A mobile-first, all-in-one theatre app_
@@ -14,23 +20,23 @@ After learning from the [first iteration](/portfolio/theatre-app) — which trie
 
 ## Phase 1: Rankings & Visualization
 
-The original inspiration for building this app is a shared note that I have with a few friends, which we use to log and rank all of the shows we see (Broadway, touring, etc.), so I wanted this to be the first feature. In addition to a simple and clean interface for rankings the shows you've seen, a visualization cloud (similar to the [theatre page on this site](/for-fun/theatre)) is automatically created. 
+The original inspiration for building this app is a shared note that I have with a few friends, which we use to log and rank all of the shows we see (Broadway, touring, etc.), so I wanted this to be the first feature. In addition to a simple and clean interface for rankings the shows you've seen, a visualization cloud (similar to the [theatre page on this site](/for-fun/theatre)) is automatically created.
 
 ## Phase 2: Shows vs. Productions vs. Visits
 
-I wanted to refine the data structure before getting too far, and I eventually landed on distinguishing between *shows, productions, and visits*. Each *show* (e.g. Hadestown) can have multiple *productions* (e.g. Broadway 2019, West End 2024, touring 2021), and *productions* can have various *visits* (e.g. "saw the touring Hadestown production in Cleveland, OH on February 13th, 2023" and "saw Hadestown on Broadway on January 20th, 2025"). 
+I wanted to refine the data structure before getting too far, and I eventually landed on distinguishing between _shows, productions, and visits_. Each _show_ (e.g. Hadestown) can have multiple _productions_ (e.g. Broadway 2019, West End 2024, touring 2021), and _productions_ can have various _visits_ (e.g. "saw the touring Hadestown production in Cleveland, OH on February 13th, 2023" and "saw Hadestown on Broadway on January 20th, 2025").
 
-While I do think this is a solid structure for the backend, it's not exactly how users think about their theatre history, nor is it valuable for this data to be presented in a strictly hierarchical way. Rather, I decided that the primary pieces of information should ultimately be "Which show did you see?" and "Where/when did you see it?" when it comes to how the app displays this hierarchical data. 
+While I do think this is a solid structure for the backend, it's not exactly how users think about their theatre history, nor is it valuable for this data to be presented in a strictly hierarchical way. Rather, I decided that the primary pieces of information should ultimately be "Which show did you see?" and "Where/when did you see it?" when it comes to how the app displays this hierarchical data.
 
-Rather than a bottom-up approach, where data becomes unusable if it's missing any fields, we can take a top-down approach, where the important info is guaranteed to exist and everything else is gravy. 
+Rather than a bottom-up approach, where data becomes unusable if it's missing any fields, we can take a top-down approach, where the important info is guaranteed to exist and everything else is gravy.
 
-For example, if I open the app and simply log that I saw Hamilton, then we have all the info needed to create a post that shows up in a social feed. This is much better than data becoming invalid just because one field was left out, even if everything else was manually added by the user. Providing a location has high value for low effort - since basically all other info can be inferred from a show, date, and location - but is still not strictly necessary. 
+For example, if I open the app and simply log that I saw Hamilton, then we have all the info needed to create a post that shows up in a social feed. This is much better than data becoming invalid just because one field was left out, even if everything else was manually added by the user. Providing a location has high value for low effort - since basically all other info can be inferred from a show, date, and location - but is still not strictly necessary.
 
-This provides a low-friction experience with the *option* of adding more info, rather than a high-friction experience that *requires* maximum data input.
+This provides a low-friction experience with the _option_ of adding more info, rather than a high-friction experience that _requires_ maximum data input.
 
 ## Phase 3: Social
 
-With the new data structure discussed above, a "social feed" feature becomes much simpler to create. 
+With the new data structure discussed above, a "social feed" feature becomes much simpler to create.
 
 Users can follow other theatre lovers, post updates and thoughts on shows, and see what your friends are posting too.
 
@@ -38,7 +44,7 @@ Currently, "posts" are only created when adding a new visit/show, but the data s
 
 ## Phase 4: Future
 
-Features such as trip planning, a ticket marketplace, a recommendation engine, and many more would bring this app away from just a "theatre diary" and more towards the "all-in-one theatre app" that I envision. 
+Features such as trip planning, a ticket marketplace, a recommendation engine, and many more would bring this app away from just a "theatre diary" and more towards the "all-in-one theatre app" that I envision.
 
 ## Technologies Used
 

--- a/app/portfolio/projects/trackwork-automation.mdx
+++ b/app/portfolio/projects/trackwork-automation.mdx
@@ -3,6 +3,7 @@ title: "Automating Railroad Design"
 completedAt: "2025-01-15"
 summary: "Automation programs for repetitive design work, specifically for railroad trackwork components"
 tags: ["Mechanical", "Software"]
+featured: 4
 ---
 
 _Building programs to parametrize and automate entire CAD processes for railroad trackwork_

--- a/app/portfolio/utils.ts
+++ b/app/portfolio/utils.ts
@@ -12,7 +12,69 @@ type Metadata = {
   githubUrl?: string
   liveUrl?: string
   tags?: string[]
+  featured?: number
+  ctas?: Array<{
+    label: string
+    href: string
+    icon?: string
+  }>
   [key: string]: any
+}
+
+function parseScalarValue(value: string) {
+  return value.replace(/^['"](.*)['"]$/, '$1')
+}
+
+function parseTagsValue(value: string) {
+  try {
+    const cleanValue = parseScalarValue(value)
+    const parsedTags = JSON.parse(cleanValue)
+    return Array.isArray(parsedTags) ? parsedTags : [parsedTags]
+  } catch {
+    const cleanValue = parseScalarValue(value)
+    return cleanValue.split(',').map(tag => parseScalarValue(tag.trim()))
+  }
+}
+
+function parseCtas(lines: string[], startIndex: number) {
+  const ctas: Metadata['ctas'] = []
+  let currentCta: NonNullable<Metadata['ctas']>[number] | null = null
+  let index = startIndex + 1
+
+  while (index < lines.length) {
+    const line = lines[index]
+
+    if (!line.startsWith(' ') && !line.startsWith('-')) {
+      break
+    }
+
+    const trimmedLine = line.trim()
+
+    if (trimmedLine.startsWith('- ')) {
+      if (currentCta) {
+        ctas.push(currentCta)
+      }
+
+      currentCta = {} as NonNullable<Metadata['ctas']>[number]
+      const rest = trimmedLine.slice(2)
+
+      if (rest.includes(': ')) {
+        const [key, ...valueArr] = rest.split(': ')
+        currentCta[key.trim() as keyof NonNullable<Metadata['ctas']>[number]] = parseScalarValue(valueArr.join(': ').trim())
+      }
+    } else if (currentCta && trimmedLine.includes(': ')) {
+      const [key, ...valueArr] = trimmedLine.split(': ')
+      currentCta[key.trim() as keyof NonNullable<Metadata['ctas']>[number]] = parseScalarValue(valueArr.join(': ').trim())
+    }
+
+    index += 1
+  }
+
+  if (currentCta) {
+    ctas.push(currentCta)
+  }
+
+  return { ctas: ctas?.filter(cta => cta.label && cta.href), nextIndex: index }
 }
 
 function parseFrontmatter(fileContent: string) {
@@ -36,31 +98,48 @@ function parseFrontmatter(fileContent: string) {
   let frontMatterLines = frontMatterBlock.trim().split('\n')
   let metadata: Partial<Metadata> = {}
 
-  frontMatterLines.forEach((line) => {
-    let [key, ...valueArr] = line.split(': ')
-    let value = valueArr.join(': ').trim()
-    
-    // Handle tags array specially
-    if (key.trim() === 'tags') {
-      // Parse array format like ["tag1", "tag2"] or ["tag1", "tag2"]
-      try {
-        // Remove outer quotes if present
-        const cleanValue = value.replace(/^['"](.*)['"]$/, '$1')
-        // Parse as JSON array
-        const parsedTags = JSON.parse(cleanValue)
-        metadata[key.trim() as keyof Metadata] = Array.isArray(parsedTags) ? parsedTags : [parsedTags]
-      } catch {
-        // Fallback to comma-separated parsing
-        const cleanValue = value.replace(/^['"](.*)['"]$/, '$1')
-        metadata[key.trim() as keyof Metadata] = cleanValue.split(',').map(tag => tag.trim().replace(/^['"](.*)['"]$/, '$1'))
-      }
-    } else {
-      value = value.replace(/^['"](.*)['"]$/, '$1') // Remove quotes
-      metadata[key.trim() as keyof Metadata] = value
+  for (let index = 0; index < frontMatterLines.length; index += 1) {
+    const line = frontMatterLines[index]
+
+    if (!line.trim() || !line.includes(':')) {
+      continue
     }
-  })
+
+    let [key, ...valueArr] = line.split(':')
+    const trimmedKey = key.trim()
+    let value = valueArr.join(':').trim()
+
+    if (trimmedKey === 'tags') {
+      metadata.tags = parseTagsValue(value)
+    } else if (trimmedKey === 'featured') {
+      metadata.featured = Number(value)
+    } else if (trimmedKey === 'ctas') {
+      const parsedCtas = parseCtas(frontMatterLines, index)
+      metadata.ctas = parsedCtas.ctas
+      index = parsedCtas.nextIndex - 1
+    } else {
+      metadata[trimmedKey as keyof Metadata] = parseScalarValue(value)
+    }
+  }
 
   return { metadata: metadata as Metadata, content }
+}
+
+function sortByFeatured<T extends { metadata: Metadata }>(items: T[]) {
+  return items
+    .filter(item => item.metadata.featured !== undefined && !Number.isNaN(item.metadata.featured))
+    .sort((a, b) => {
+      const aFeatured = a.metadata.featured ?? Number.MAX_SAFE_INTEGER
+      const bFeatured = b.metadata.featured ?? Number.MAX_SAFE_INTEGER
+
+      if (aFeatured !== bFeatured) {
+        return aFeatured - bFeatured
+      }
+
+      const aDate = new Date(a.metadata.completedAt || '1900-01-01')
+      const bDate = new Date(b.metadata.completedAt || '1900-01-01')
+      return bDate.getTime() - aDate.getTime()
+    })
 }
 
 function getMDXFiles(dir) {
@@ -94,4 +173,8 @@ export function getPortfolioProjects() {
       completedAt: project.metadata.completedAt || new Date().toISOString()
     }
   }))
-} 
+}
+
+export function getFeaturedPortfolioProjects() {
+  return sortByFeatured(getPortfolioProjects())
+}


### PR DESCRIPTION
## Summary

This PR adds manually ordered featured content for the home page, portfolio index, and blog index. Portfolio project cards can show optional CTA buttons (e.g. App Store and website for Stageworth / Theatre Diary).

## Changes

- **Loaders**: Parse `featured` (numeric order) on posts and projects; parse optional `ctas` on portfolio MDX frontmatter.
- **UI**: Compact grid cards support CTAs without nested links; section "see all" appears only beside the header (duplicate below the grid removed).
- **Pages**: Home shows only featured items with "Featured Projects" / "Featured Blogs" headings. Portfolio and blog indexes show a featured block (up to six) plus full chronological lists.
- **Content**: Sets the initial featured project and blog set and Stageworth links on Theatre Diary.

## Notes

Local unrelated changes (`.gitignore`, lockfile, untracked posts) were not included in these commits.

Made with [Cursor](https://cursor.com)